### PR TITLE
🎨 Palette: Add CLI arguments and accessibility flags

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-22 - Visual Hierarchy in CLI Output
 **Learning:** Adding color-coded indicators (Green/Red) and emojis (💰, 📉) in CLI tools significantly reduces cognitive load when parsing financial data streams. It transforms a wall of text into a scannable narrative.
 **Action:** For data-heavy CLI applications, always implement a semantic color system and visual anchors (icons/emojis) for key events.
+
+## 2026-02-06 - CLI Accessibility Standards
+**Learning:** CLI tools are surprisingly inaccessible without standard flags like `--no-color` and `--quiet`. Users expect these controls to integrate with scripts and accessibility tools.
+**Action:** Always implement `argparse` with quiet/color-disable options for any CLI outputting more than 5 lines.

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@
 
 # debug information files
 *.dwo
+
+# Python
+__pycache__/
+*.pyc

--- a/bitcoin_trading_simulation.py
+++ b/bitcoin_trading_simulation.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import argparse
 
 class Colors:
     HEADER = '\033[95m'
@@ -8,6 +9,15 @@ class Colors:
     RED = '\033[91m'
     ENDC = '\033[0m'
     BOLD = '\033[1m'
+
+    @classmethod
+    def disable(cls):
+        cls.HEADER = ''
+        cls.BLUE = ''
+        cls.GREEN = ''
+        cls.RED = ''
+        cls.ENDC = ''
+        cls.BOLD = ''
 
 def simulate_bitcoin_prices(days=60, initial_price=50000, volatility=0.02):
     """
@@ -49,7 +59,7 @@ def generate_trading_signals(signals):
     signals['positions'] = signals['signal'].diff().shift(1)
     return signals
 
-def simulate_trading(signals, initial_cash=10000):
+def simulate_trading(signals, initial_cash=10000, quiet=False):
     """
     Simulates trading based on signals and prints a daily ledger.
     """
@@ -59,7 +69,8 @@ def simulate_trading(signals, initial_cash=10000):
     portfolio['btc'] = 0.0
     portfolio['total_value'] = float(initial_cash)
 
-    print(f"{Colors.HEADER}{Colors.BOLD}------ Daily Trading Ledger ------{Colors.ENDC}")
+    if not quiet:
+        print(f"{Colors.HEADER}{Colors.BOLD}------ Daily Trading Ledger ------{Colors.ENDC}")
     for i, row in signals.iterrows():
         if i > 0:
             portfolio.loc[i, 'cash'] = portfolio.loc[i-1, 'cash']
@@ -70,24 +81,40 @@ def simulate_trading(signals, initial_cash=10000):
             btc_to_buy = portfolio.loc[i, 'cash'] / row['price']
             portfolio.loc[i, 'btc'] += btc_to_buy
             portfolio.loc[i, 'cash'] -= btc_to_buy * row['price']
-            print(f"{Colors.GREEN}Day {i}: 💰 Buy {btc_to_buy:.4f} BTC at ${row['price']:.2f}{Colors.ENDC}")
+            if not quiet:
+                print(f"{Colors.GREEN}Day {i}: 💰 Buy {btc_to_buy:.4f} BTC at ${row['price']:.2f}{Colors.ENDC}")
 
         # Sell signal
         elif row['positions'] == -2.0:
             if portfolio.loc[i, 'btc'] > 0:
                 cash_received = portfolio.loc[i, 'btc'] * row['price']
                 portfolio.loc[i, 'cash'] += cash_received
-                print(f"{Colors.RED}Day {i}: 📉 Sell {portfolio.loc[i, 'btc']:.4f} BTC at ${row['price']:.2f}{Colors.ENDC}")
+                if not quiet:
+                    print(f"{Colors.RED}Day {i}: 📉 Sell {portfolio.loc[i, 'btc']:.4f} BTC at ${row['price']:.2f}{Colors.ENDC}")
                 portfolio.loc[i, 'btc'] = 0
 
         portfolio.loc[i, 'total_value'] = portfolio.loc[i, 'cash'] + portfolio.loc[i, 'btc'] * row['price']
-        print(f"Day {i}: Portfolio Value: ${portfolio.loc[i, 'total_value']:.2f}, Cash: ${portfolio.loc[i, 'cash']:.2f}, BTC: {portfolio.loc[i, 'btc']:.4f}")
+        if not quiet:
+            print(f"Day {i}: Portfolio Value: ${portfolio.loc[i, 'total_value']:.2f}, Cash: ${portfolio.loc[i, 'cash']:.2f}, BTC: {portfolio.loc[i, 'btc']:.4f}")
     
     return portfolio
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Bitcoin Trading Simulation')
+    parser.add_argument('--days', type=int, default=60, help='Number of days to simulate')
+    parser.add_argument('--initial-cash', type=float, default=10000, help='Initial cash amount')
+    parser.add_argument('--initial-price', type=float, default=50000, help='Initial Bitcoin price')
+    parser.add_argument('--volatility', type=float, default=0.02, help='Volatility factor')
+    parser.add_argument('--quiet', action='store_true', help='Suppress daily output')
+    parser.add_argument('--no-color', action='store_true', help='Disable colored output')
+
+    args = parser.parse_args()
+
+    if args.no_color:
+        Colors.disable()
+
     # Simulate prices
-    prices = simulate_bitcoin_prices()
+    prices = simulate_bitcoin_prices(days=args.days, initial_price=args.initial_price, volatility=args.volatility)
     
     # Calculate moving averages
     signals = calculate_moving_averages(prices)
@@ -96,11 +123,11 @@ if __name__ == "__main__":
     signals = generate_trading_signals(signals)
     
     # Simulate trading
-    portfolio = simulate_trading(signals)
+    portfolio = simulate_trading(signals, initial_cash=args.initial_cash, quiet=args.quiet)
     
     # Final portfolio performance
     final_value = portfolio['total_value'].iloc[-1]
-    initial_cash = 10000
+    initial_cash = args.initial_cash
     profit = final_value - initial_cash
     
     # Compare with buy and hold strategy

--- a/test.py
+++ b/test.py
@@ -1,3 +1,0 @@
-# Filename: tests/test_sample.py
-def test_example():
-    assert 1 + 1 == 2

--- a/test_simulation.py
+++ b/test_simulation.py
@@ -1,0 +1,33 @@
+import pytest
+import pandas as pd
+import numpy as np
+from bitcoin_trading_simulation import simulate_bitcoin_prices, calculate_moving_averages, generate_trading_signals
+
+def test_simulate_bitcoin_prices():
+    days = 10
+    prices = simulate_bitcoin_prices(days=days, initial_price=50000)
+    assert len(prices) == days
+    assert isinstance(prices, pd.Series)
+    assert prices.name == 'Price'
+
+def test_calculate_moving_averages():
+    prices = pd.Series([100, 101, 102, 103, 104, 105, 106, 107, 108, 109], name='Price')
+    signals = calculate_moving_averages(prices, short_window=3, long_window=5)
+    assert 'short_mavg' in signals.columns
+    assert 'long_mavg' in signals.columns
+    assert not signals['short_mavg'].isnull().all()
+
+def test_generate_trading_signals():
+    # Create dummy signals DataFrame
+    data = {
+        'price': [100, 101, 102, 103, 104],
+        'short_mavg': [100, 101, 105, 102, 100],
+        'long_mavg':  [100, 100, 100, 103, 105]
+    }
+    signals = pd.DataFrame(data)
+    signals = generate_trading_signals(signals)
+
+    assert 'signal' in signals.columns
+    assert 'positions' in signals.columns
+    # Check that positions are calculated (not all nan, though first might be)
+    assert signals['positions'].isin([0, 1, -1, 2, -2, np.nan]).any()


### PR DESCRIPTION
💡 What: Added `argparse` to `bitcoin_trading_simulation.py` to support command-line arguments.
🎯 Why: Users could not configure the simulation (days, cash) without editing code. The output was also hardcoded with colors and verbose logging, which isn't always desired.
📸 Before: Hardcoded run (60 days, colored output).
   After: `python bitcoin_trading_simulation.py --days 10 --quiet --no-color`
♿ Accessibility: Added `--no-color` flag for users with color vision deficiencies or incompatible terminal themes. Added `--quiet` for screen reader users who don't want to hear 60 lines of daily values.

---
*PR created automatically by Jules for task [8778900321519029465](https://jules.google.com/task/8778900321519029465) started by @EiJackGH*