### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain persmissons

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,6 +13,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add Persmissons to /.github/workflows/python-package.yml
