### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Workflow does not contain permissions

### Incorrect:
```yaml
name: "My workflow"
# No permissions block
``` 

### Correct:
```yaml
name: "My workflow"
permissions:
  contents: read
  pull-requests: write
``` 



Potential fix for code scanning alerts no. 2: Workflow does not contain permissions
To fix, Add:
```yaml
permissions:
  contents: read
``` 
or
```yaml
jobs:
  my-job:
    permissions:
      contents: read
      pull-requests: write
``` 
Add a block to the this `permissions:
contents: read` to the rust.yml