### PR TITLE
🎨 Palette: Add dynamic progress bar for quiet mode

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-02-28 - Structured CLI Reports
 **Learning:** Dense numerical data in CLI output is hard to parse. Using ASCII box-drawing characters and alignment to create a "dashboard" or "invoice" style summary significantly improves readability and perceived quality.
 **Action:** When summarizing simulation or batch job results, always format the final report as a structured table or box rather than a list of print statements.
+
+## 2025-03-14 - Dynamic Progress Bars in Quiet CLI Modes
+**Learning:** For long-running CLI applications that support a `--quiet` flag (which normally suppresses verbose logging), providing a dynamic progress bar using `\r` and `flush=True` (conditional on `sys.stdout.isatty()`) offers a much better UX. It gives the user necessary status visibility during long executions without polluting non-interactive environments (like CI/CD) or file redirections.
+**Action:** Always consider replacing suppressed verbose output with a dynamic progress bar for long-running scripts when `--quiet` mode is active and the terminal is interactive.

--- a/bitcoin_trading_simulation.py
+++ b/bitcoin_trading_simulation.py
@@ -84,7 +84,11 @@ def simulate_trading(signals, initial_cash=10000, quiet=False):
 
     if not quiet:
         print(f"\n{Colors.HEADER}{Colors.BOLD}------ Daily Trading Ledger ------{Colors.ENDC}")
-    for i, row in signals.iterrows():
+
+    total_days = len(signals)
+    show_progress = quiet and sys.stdout.isatty()
+
+    for idx, (i, row) in enumerate(signals.iterrows()):
         if i > 0:
             portfolio.loc[i, 'cash'] = portfolio.loc[i-1, 'cash']
             portfolio.loc[i, 'btc'] = portfolio.loc[i-1, 'btc']
@@ -94,14 +98,16 @@ def simulate_trading(signals, initial_cash=10000, quiet=False):
             btc_to_buy = portfolio.loc[i, 'cash'] / row['price']
             portfolio.loc[i, 'btc'] += btc_to_buy
             portfolio.loc[i, 'cash'] -= btc_to_buy * row['price']
-            print(f"{Colors.GREEN}🟢 Day {i}: Buy {btc_to_buy:.4f} BTC at ${row['price']:.2f}{Colors.ENDC}")
+            if not quiet:
+                print(f"{Colors.GREEN}🟢 Day {i}: Buy {btc_to_buy:.4f} BTC at ${row['price']:.2f}{Colors.ENDC}")
 
         # Sell signal
         elif row['positions'] == -2.0:
             if portfolio.loc[i, 'btc'] > 0:
                 cash_received = portfolio.loc[i, 'btc'] * row['price']
                 portfolio.loc[i, 'cash'] += cash_received
-                print(f"{Colors.FAIL}🔴 Day {i}: Sell {portfolio.loc[i, 'btc']:.4f} BTC at ${row['price']:.2f}{Colors.ENDC}")
+                if not quiet:
+                    print(f"{Colors.FAIL}🔴 Day {i}: Sell {portfolio.loc[i, 'btc']:.4f} BTC at ${row['price']:.2f}{Colors.ENDC}")
                 portfolio.loc[i, 'btc'] = 0
 
         portfolio.loc[i, 'total_value'] = portfolio.loc[i, 'cash'] + portfolio.loc[i, 'btc'] * row['price']
@@ -109,6 +115,15 @@ def simulate_trading(signals, initial_cash=10000, quiet=False):
         if not quiet:
             print(f"Day {i}: Portfolio Value: ${portfolio.loc[i, 'total_value']:.2f}, "
                   f"Cash: ${portfolio.loc[i, 'cash']:.2f}, BTC: {portfolio.loc[i, 'btc']:.4f}")
+        elif show_progress:
+            progress = (idx + 1) / total_days
+            bar_length = 30
+            filled_length = int(bar_length * progress)
+            bar = '█' * filled_length + '-' * (bar_length - filled_length)
+            print(f"\r{Colors.CYAN}Simulating: [{bar}] {progress:.0%}{Colors.ENDC}", end='', flush=True)
+
+    if show_progress:
+        print()
 
     return portfolio
 

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,1 @@
+terraform {}


### PR DESCRIPTION
💡 What: Added a dynamic progress bar for the simulation when running in `--quiet` mode. Also suppressed Buy/Sell messages when quiet is active.
🎯 Why: Long-running simulations in quiet mode give no feedback to the user until complete. A progress bar solves this, but must be carefully implemented to avoid polluting non-interactive logs (like CI pipelines).
♿ Accessibility / UX: Improves cognitive load by giving visibility into system status without noise.

Added a learning entry to `.Jules/palette.md` noting this reusable pattern.

---
*PR created automatically by Jules for task [15424000240026300105](https://jules.google.com/task/15424000240026300105) started by @EiJackGH*