### PR TITLE
Fix Dependabot configuration syntax and add terraform ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-   package-ecosystem: "pip"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -21,6 +21,11 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "terraform"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The Dependabot configuration file had a syntax error that prevented it from being parsed. The `pip` update entry was missing a hyphen and had incorrect indentation. This PR fixes the syntax and also adds the `terraform` ecosystem to the list of tracked dependencies to match the project's requirements.

---
*PR created automatically by Jules for task [15335264064245797101](https://jules.google.com/task/15335264064245797101) started by @EiJackGH*