### PR TITLE
🎨 Palette: [Mario Game] Keyboard control refinement and a11y improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-05-20 - Dynamic Progress Bar for Quiet CLI Tasks
 **Learning:** For long-running CLI processes that suppress verbose logging (e.g., `--quiet`), users lose system status visibility.
 **Action:** Implemented a dynamic progress bar using `\r` and `flush=True`, conditional on `sys.stdout.isatty()`, to provide status feedback without polluting non-interactive logs.
+
+## 2024-05-24 - Web Game Keyboard Controls UX
+**Learning:** Using 'Space' or 'Arrow' keys to trigger interactions in web apps (like jumping in a game) without calling `e.preventDefault()` causes the browser to naturally scroll the page. This breaks the gameplay experience as the user is thrown out of context.
+**Action:** Always capture and prevent default behavior on keyboard events that share bindings with native browser navigation (like Space/Arrow keys for scrolling) when implementing custom interactive widgets or games.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,23 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #hint {
+      position: absolute;
+      top: 35px;
+      left: 10px;
+      color: rgba(255, 255, 255, 0.8);
+      font-size: 14px;
+      font-family: Arial;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite">Score: 0</div>
+  <div id="hint">Press Space to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>
@@ -72,7 +82,13 @@
   let score = 0;
 
   // Jump mechanic
-  document.addEventListener("keydown", () => {
+  document.addEventListener("keydown", (e) => {
+    if (e.code === "Space" || e.code === "ArrowUp") {
+      e.preventDefault(); // Prevent page scrolling
+    } else {
+      return;
+    }
+
     if (jumping) return;
 
     jumping = true;


### PR DESCRIPTION
**💡 What:** 
Added a clear visual instruction for gameplay ("Press Space to jump"), limited jumping input to Space and ArrowUp keys, prevented default page scrolling when using these keys, and added `aria-live="polite"` to the score element.

**🎯 Why:**
- Users didn't know which keys to press to play the game.
- If the game was embedded in a scrollable page, pressing Space or ArrowUp to jump would also scroll the browser window down, ruining the gameplay experience.
- Screen readers were not naturally announcing the dynamic score updates.

**📸 Before/After:**
*Before:* No visual hint, jumping on any key, page scrolls on Space.
*After:* See screenshot for visual hint; jumping limited to specific keys and page scrolling is blocked.

**♿ Accessibility:**
- Added `aria-live="polite"` to the `#score` element so screen readers will read out the score changes organically.
- Prevented keyboard interaction from breaking focus/viewport position by preventing default browser scrolling.

---
*PR created automatically by Jules for task [14150505555651676540](https://jules.google.com/task/14150505555651676540) started by @EiJackGH*