### PR TITLE
🎨 Palette: Mario Game UX Accessibility & Hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+## 2024-05-02 - Web Game UX Accessibility
+**Learning:** For in-browser interactive elements like HTML5 games running in a standard document context, dynamic states (like scores) are visually obvious but entirely invisible to screen readers unless specifically marked.
+**Action:** Always add `aria-live="polite"` and `aria-atomic="true"` to dynamic score/status elements in web-based mini-games to ensure accessibility isn't forgotten in "toy" components. Additionally, for components that hijack default keyboard behaviors (like Space to scroll), provide a visual, screen-reader-hidden `aria-hidden="true"` control hint if it's the primary mode of interaction.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 pandas
 requests
-venv

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -51,6 +51,20 @@
       color: white;
       font-size: 20px;
       font-family: Arial;
+      z-index: 10;
+    }
+
+    #controls-hint {
+      position: absolute;
+      top: 40px;
+      left: 10px;
+      color: rgba(255, 255, 255, 0.8);
+      font-size: 14px;
+      font-family: Arial;
+      z-index: 10;
+      background: rgba(0, 0, 0, 0.3);
+      padding: 4px 8px;
+      border-radius: 4px;
     }
   </style>
 </head>
@@ -58,7 +72,8 @@
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite" aria-atomic="true">Score: 0</div>
+  <div id="controls-hint" aria-hidden="true">Press Space or Up Arrow to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
💡 **What:** Added `aria-live="polite"` and `aria-atomic="true"` to the dynamic score counter and introduced a semi-transparent, floating keyboard controls hint ("Press Space or Up Arrow to jump") underneath the score in the Mario game. Also fixed a CI failure by stripping the invalid standard library `venv` module from `requirements.txt`.

🎯 **Why:** The score was dynamically updating but completely inaccessible to screen readers. Furthermore, players landing on the page had no way to know the game controls other than guessing or reading the source code. This small hint reduces cognitive friction, and the aria updates make the widget inclusive.

📸 **Before/After:** The game now displays a "Press Space or Up Arrow to jump" hint below the score on page load. Playwright screenshots show it perfectly overlays the game background without obstructing the gameplay area.

♿ **Accessibility:** Added ARIA live regions to the score counter. The controls hint was marked with `aria-hidden="true"` as visual help, ensuring it doesn't clutter screen reader announcements where basic interaction might already be implied or read from surrounding context.

---
*PR created automatically by Jules for task [790433205743827776](https://jules.google.com/task/790433205743827776) started by @EiJackGH*