### PR TITLE
🎨 Palette: Add keyboard instructions and ARIA attributes to Mario game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+## 2024-05-09 - Interactive Game Accessibility
+**Learning:** Adding text instructions to canvas/custom interactive elements is crucial since standard screen readers or navigation patterns might not infer custom game controls.
+**Action:** Always provide explicit, visible instructional text so users know the required inputs for interactive web games.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 pandas
 requests
-venv

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,26 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      color: white;
+      font-size: 20px;
+      font-family: Arial;
+      background: rgba(0, 0, 0, 0.5);
+      padding: 5px 10px;
+      border-radius: 5px;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite" aria-atomic="true">Score: 0</div>
+  <div id="instructions">Press Space or &uarr; to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
**💡 What:** 
Added visible keyboard instructions ("Press Space or ↑ to jump") to the top right of the game container. Also added `aria-live="polite"` and `aria-atomic="true"` to the score container. Additionally, I removed `venv` from `requirements.txt` to fix pip installations.

**🎯 Why:**
Users need to know what keys to press to interact with the game. Without instructions, the custom keybindings are a guess.

**📸 Before/After:**
Before: The top right was empty and the score wasn't announced.
After: The top right has "Press Space or ↑ to jump" with a semi-transparent dark background.

**♿ Accessibility:**
The new ARIA attributes ensure that screen readers will correctly read out the dynamic score when it is updated. The explicit visible instructions help users with cognitive or interactive needs know how to play.

---
*PR created automatically by Jules for task [7637536614692917530](https://jules.google.com/task/7637536614692917530) started by @EiJackGH*