### PR TITLE
🎨 Palette: Add keyboard instructions and accessible score to Mario game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,11 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+
+## 2025-05-18 - Missing Screen Reader Feedback on Dynamic Scores
+**Learning:** For dynamic real-time values like game scores that update frequently without page reloads, screen reader users miss out on crucial context if live regions are not used. Adding `aria-live` is critical.
+**Action:** Always include `aria-live="polite"` and `aria-atomic="true"` on scoreboards, progress indicators, or dynamic text containers in custom UI or web games to ensure announcements are properly queued and read out.
+
+## 2025-05-18 - "Invisible" Controls in Custom Game UIs
+**Learning:** Creating custom keyboard event listeners in web interfaces (like space to jump) is often totally undiscoverable to users without explicit onboarding text.
+**Action:** Whenever binding custom navigation or game actions to keydown events, verify that instructional helper text is visibly rendered in the UI context so users know what inputs are expected.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 pandas
 requests
-venv

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,26 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      color: rgba(255, 255, 255, 0.8);
+      font-size: 16px;
+      font-family: Arial, sans-serif;
+      background: rgba(0, 0, 0, 0.3);
+      padding: 5px 10px;
+      border-radius: 5px;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite" aria-atomic="true">Score: 0</div>
+  <div id="instructions" aria-hidden="true">Press <b>Space</b> or <b>Up Arrow</b> to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
### 💡 What
Added an explicitly visible keyboard instructional text block (`#instructions`) and added screen-reader accessible live regions to the dynamic `#score` element in the Mario game. Also removed an invalid entry `venv` from `requirements.txt` to fix pip installs.

### 🎯 Why
Custom key bindings in web UIs are undiscoverable without explicit text. Adding a small instructional box immediately teaches users how to interact with the game. In addition, real-time value updates (like score) require `aria-live` tags to be announced by screen readers, which was previously missing.

### 📸 Before/After
*(See Playwright screenshot from verification phase: instruction text in the top right corner over the blue sky)*

### ♿ Accessibility
- Added `aria-live="polite"` to `#score` to queue and announce score changes to screen readers gracefully.
- Added `aria-hidden="true"` to visual instructions so screen readers aren't forced to announce static visual styling rules if not needed.

---
*PR created automatically by Jules for task [7492972733585240345](https://jules.google.com/task/7492972733585240345) started by @EiJackGH*