### PR TITLE
🎨 Palette: Add explicit controls and a11y score announcements to Mario Game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+## 2026-05-19 - Screen Reader Support for Real-Time Game UI Updates
+**Learning:** Dynamic UI elements in HTML5 games (like a live score counter) are completely invisible to screen readers by default.
+**Action:** Always add `aria-live="polite"` and `aria-atomic="true"` to game status elements (scores, health, timers) so screen readers automatically announce changes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 pandas
 requests
-venv

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,23 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #controls-hint {
+      position: absolute;
+      top: 40px;
+      left: 10px;
+      color: rgba(255, 255, 255, 0.8);
+      font-size: 14px;
+      font-family: Arial;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite" aria-atomic="true">Score: 0</div>
+  <div id="controls-hint">Press Space or ↑ to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
### 💡 What
- Added visible "Press Space or ↑ to jump" text hint directly beneath the score counter.
- Added `aria-live="polite"` and `aria-atomic="true"` attributes to the score display.
- Removed the problematic standard library `venv` module from `requirements.txt` to unblock package installation.

### 🎯 Why
- Players had no visual indication of what keys mapped to the jump action, making the game unapproachable for first-time users.
- The real-time score updates were visually apparent but invisible to assistive technologies.
- `pip install -r requirements.txt` was failing out-of-the-box due to the `venv` module.

### 📸 Before/After
_Before:_ Just a "Score: 0" in the top left, no instructions.
_After:_ "Score: 0" with a subtle, stylistically-matched "Press Space or ↑ to jump" below it.

### ♿ Accessibility
- **Screen Reader Support:** Screen readers will now automatically announce changes to the score counter as the player progresses, providing non-visual feedback for game success.
- **Cognitive UX:** Explicit control text reduces cognitive load and removes guesswork.

---
*PR created automatically by Jules for task [7199771241939311346](https://jules.google.com/task/7199771241939311346) started by @EiJackGH*