### PR TITLE
🎨 Palette: Add keyboard shortcut hints and score accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+
+## 2024-05-26 - Dynamic Web Game Content Accessibility
+**Learning:** Screen readers won't automatically announce dynamic updates in games (like scores or lives) unless explicitly configured.
+**Action:** Always add `aria-live="polite"` and `aria-atomic="true"` to dynamic game text elements (like score counters) to ensure accessibility for visually impaired users.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 pandas
 requests
-venv

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,23 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #controls-hint {
+      position: absolute;
+      top: 40px;
+      left: 10px;
+      color: rgba(255, 255, 255, 0.8);
+      font-size: 14px;
+      font-family: Arial;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite" aria-atomic="true">Score: 0</div>
+  <div id="controls-hint">Press Space or &uarr; to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
### 💡 What
Added a visual hint for game controls and ARIA attributes for dynamic score updates. Also removed the built-in `venv` module from `requirements.txt`.

### 🎯 Why
- Users may not intuitively know that "Space" or "Up Arrow" are the jump keys. Explicit instructions remove friction.
- Screen readers won't announce the dynamic score updates by default, making the game confusing for visually impaired players.
- The `venv` package in `requirements.txt` breaks automated pipeline/pip install commands.

### 📸 Before/After
*(Visual changes verified via local Playwright screenshot)*
**Before**: Only "Score: 0" is visible.
**After**: "Press Space or ↑ to jump" appears below the score.

### ♿ Accessibility
Added `aria-live="polite"` and `aria-atomic="true"` to the score counter.

---
*PR created automatically by Jules for task [15586601323412645856](https://jules.google.com/task/15586601323412645856) started by @EiJackGH*