### PR TITLE
🎨 Palette: Add keyboard instructions and screen reader support to Mario game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+
+## 2026-05-30 - HTML5 Game Accessibility
+**Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users need explicit instructions, and dynamic status updates like scores require proper ARIA attributes to be accessible to screen readers.
+**Action:** Always provide visible instructional text for custom controls, and add `aria-live="polite"` and `aria-atomic="true"` to elements like game scores that update dynamically.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 pandas
 requests
-venv

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,26 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    .instructions {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      color: white;
+      font-size: 16px;
+      font-family: Arial;
+      background: rgba(0, 0, 0, 0.5);
+      padding: 5px 10px;
+      border-radius: 5px;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite" aria-atomic="true">Score: 0</div>
+  <div class="instructions">Press Space or Up Arrow to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
### 💡 What
Added explicit keyboard control instructions to the Mario game UI (`src/views/mario-game.njk`) and applied `aria-live="polite"` and `aria-atomic="true"` to the dynamic score element. Also removed a broken `venv` entry from `requirements.txt` that was blocking local testing.

### 🎯 Why
The custom game keyboard controls ("Space" and "ArrowUp") were previously hidden/undiscoverable, forcing users to guess the inputs. Furthermore, the dynamic score updates were completely invisible to users relying on screen readers.

### 📸 Before/After
*(Please refer to the generated Playwright verification screenshot/video in the PR comments or CI artifacts)*
The instructions now prominently display "Press Space or Up Arrow to jump" in a styled, semi-transparent box in the top right corner.

### ♿ Accessibility
- Added `aria-live="polite"` to the `#score` element so screen readers can announce when the score updates as Goombas are defeated.
- Added `aria-atomic="true"` to ensure the full score string (e.g. "Score: 1") is read out instead of just the changed digit.
- Ensured instructional text has good color contrast (white text on semi-transparent black background).

---
*PR created automatically by Jules for task [15820472824349540055](https://jules.google.com/task/15820472824349540055) started by @EiJackGH*