### PR TITLE
🎨 Palette: Add accessible instructions and score to Mario game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+
+## 2026-07-02 - Web Game Keyboard Accessibility and Instructions
+**Learning:** For interactive HTML5 widgets or games with custom keyboard event bindings, always provide explicit, visible instructional text so users know the required inputs. Additionally, do not place static text (like instructions) inside an `aria-live` region, as it forces screen readers to unnecessarily repeat the static text every time the dynamic content updates. Extract static text into a separate sibling element.
+**Action:** When adding dynamic status updates (like scores) alongside instructions, keep them as separate elements. Add `aria-live="polite"` and `aria-atomic="true"` only to the element containing the dynamic content to maintain clean screen reader announcements.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,24 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 35px;
+      left: 10px;
+      color: white;
+      font-size: 14px;
+      font-family: Arial;
+      opacity: 0.8;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite" aria-atomic="true">Score: 0</div>
+  <div id="instructions">Press Space or Up Arrow to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
**💡 What:** Added visible keyboard instructions ("Press Space or Up Arrow to jump") to the Mario game UI. Also added `aria-live="polite"` and `aria-atomic="true"` attributes to the score display container.

**🎯 Why:** Users previously had no immediate visual indication of what keys were required to play the game, leading to initial confusion. Adding these clear, unobtrusive instructions improves discoverability and the overall onboarding experience.

**📸 Before/After:** The instructions are now displayed subtly below the score in the top left corner, matching the existing visual hierarchy of the UI.

**♿ Accessibility:** The newly added `aria-live` and `aria-atomic` attributes ensure that screen readers can correctly and cleanly announce dynamic score updates to visually impaired users during gameplay, while the static instructions are kept in a separate sibling container to avoid redundant voice-overs.

---
*PR created automatically by Jules for task [2420633220270642582](https://jules.google.com/task/2420633220270642582) started by @EiJackGH*