### PR TITLE
🎨 Palette: Add keyboard instructions and improve score accessibility

### DIFF
--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,26 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      color: white;
+      font-size: 16px;
+      font-family: Arial;
+      background: rgba(0, 0, 0, 0.5);
+      padding: 5px 10px;
+      border-radius: 5px;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score">Score: <span id="score-value" aria-live="polite" aria-atomic="true">0</span></div>
+  <div id="instructions">Press <strong>Space</strong> or <strong>Up Arrow</strong> to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>
@@ -66,7 +79,7 @@
 <script>
   const mario = document.getElementById("mario");
   const game = document.getElementById("game");
-  const scoreText = document.getElementById("score");
+  const scoreValue = document.getElementById("score-value");
 
   let jumping = false;
   let score = 0;
@@ -118,7 +131,7 @@
         clearInterval(move);
         goomba.remove();
         score++;
-        scoreText.innerText = "Score: " + score;
+        scoreValue.innerText = score;
       } else {
         position -= 6;
         goomba.style.left = position + "px";


### PR DESCRIPTION
💡 **What**: 
Added visible instructional text ("Press Space or Up Arrow to jump") for the keyboard controls and improved screen reader accessibility for the score display.

🎯 **Why**: 
Users (especially non-gamers) might not intuitively know which keys to press. Furthermore, the dynamic score text was not properly announced by screen readers, and replacing the entire "Score: X" string repeatedly is bad practice for a11y.

📸 **Before/After**: 
Before: No visible instructions, score updated entire text block.
After: Explicit instructions in top right corner, score updates only the number within an `aria-live` span.

♿ **Accessibility**: 
- Added `aria-live="polite"` and `aria-atomic="true"` to the dynamic score `<span id="score-value">` so screen readers only announce the updated score number without endlessly repeating the static "Score: " text.
- Ensured keyboard instructions have sufficient color contrast with a semi-transparent dark background.

---
*PR created automatically by Jules for task [9196131454668226907](https://jules.google.com/task/9196131454668226907) started by @EiJackGH*