### PR TITLE
Fix Dependabot YAML syntax error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-   package-ecosystem: "pip"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Fixed the Dependabot configuration error "(<unknown>): did not find expected key while parsing a block mapping at line 8 column 4" by correcting the YAML syntax in `.github/dependabot.yml`. The first item in the `updates` list was missing its sequence indicator (`-`) and had incorrect indentation. Verified the fix by reading the file and running existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [5687040673774913285](https://jules.google.com/task/5687040673774913285) started by @EiJackGH*