### PR TITLE
🎨 Palette: Add explicit game controls and aria-live score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+
+## 2025-07-10 - Explicit Game Controls and aria-live Separation
+**Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users need explicit, visible instructional text so they know the required inputs. Furthermore, it's critical to keep static instructions outside of `aria-live` regions, otherwise screen readers will unnecessarily repeat the static text every time the dynamic content updates.
+**Action:** Always provide explicit instructional text for custom controls. Extract static text into a separate sibling element away from any `aria-live` regions tracking dynamic updates like scores.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,26 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 40px;
+      left: 10px;
+      color: white;
+      font-size: 16px;
+      font-family: Arial;
+      background: rgba(0, 0, 0, 0.5);
+      padding: 5px 10px;
+      border-radius: 5px;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite" aria-atomic="true">Score: 0</div>
+  <div id="instructions">Press Space or Up Arrow to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
🎨 Palette: Add explicit game controls and aria-live score

💡 What: Added an instructional text div to the Mario game view explaining the controls ("Press Space or Up Arrow to jump") and added `aria-live="polite"` and `aria-atomic="true"` to the dynamic score div.
🎯 Why: Custom keyboard event bindings for games require explicit instructions so users know how to play. Adding `aria-live` to the score ensures screen reader users receive dynamic updates. Keeping the static instructional text out of the `aria-live` region prevents screen readers from needlessly repeating the instructions every time the score updates.
♿ Accessibility: Improved screen reader accessibility for the score counter and clarified controls.
📸 Before/After: See PR media.

---
*PR created automatically by Jules for task [12657445712183124581](https://jules.google.com/task/12657445712183124581) started by @EiJackGH*