### PR TITLE
🎨 Palette: Add keyboard instructions and accessible score to Mario Game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+## 2024-05-14 - Accessible Game Score and Controls
+**Learning:** For interactive web games, users often don't know keyboard controls if they aren't visible, and dynamic status updates like scores can be invisible to screen readers if not properly configured. Avoid placing static label text inside the `aria-live` region to prevent repetitive announcements.
+**Action:** Extract dynamic score values into an isolated `span` with `aria-live="polite"` and `aria-atomic="true"`. Add an overlay text hint for controls using `pointer-events: none` to prevent blocking mouse/touch interactions on the canvas beneath it.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,13 +52,28 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    /* Game controls instructions */
+    #instructions {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      color: white;
+      font-size: 16px;
+      font-family: Arial;
+      pointer-events: none; /* Let clicks pass through */
+      background: rgba(0, 0, 0, 0.5);
+      padding: 5px 10px;
+      border-radius: 5px;
+    }
   </style>
 </head>
 
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score">Score: <span id="score-value" aria-live="polite" aria-atomic="true">0</span></div>
+  <div id="instructions">Press Space or Up Arrow to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>
@@ -66,7 +81,7 @@
 <script>
   const mario = document.getElementById("mario");
   const game = document.getElementById("game");
-  const scoreText = document.getElementById("score");
+  const scoreValueText = document.getElementById("score-value");
 
   let jumping = false;
   let score = 0;
@@ -118,7 +133,7 @@
         clearInterval(move);
         goomba.remove();
         score++;
-        scoreText.innerText = "Score: " + score;
+        scoreValueText.innerText = score;
       } else {
         position -= 6;
         goomba.style.left = position + "px";


### PR DESCRIPTION
💡 **What**: Added visible keyboard instructions overlay to the Mario Game and improved the accessibility of the score counter by wrapping it in an `aria-live` region.
🎯 **Why**: Users who aren't familiar with standard web game conventions might not know how to jump (Space or Up Arrow). Furthermore, screen readers wouldn't automatically announce score updates.
♿ **Accessibility**: Separated the dynamic score value into a `span` with `aria-live="polite"` and `aria-atomic="true"` so screen readers will read the score naturally without repeating the static "Score:" label. The instructions overlay uses `pointer-events: none` to prevent it from blocking underlying click interactions.

---
*PR created automatically by Jules for task [11992795797682397270](https://jules.google.com/task/11992795797682397270) started by @EiJackGH*