### PR TITLE
🎨 Palette: Add explicit control instructions to Mario game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+
+## 2025-05-18 - Visible Instructions for Custom Key Bindings
+**Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users cannot intuit the required inputs on their own.
+**Action:** Always provide explicit, visible instructional text so users know the required inputs (and use `pointer-events: none` if overlaying interactive content).

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,6 +52,16 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      color: white;
+      font-size: 20px;
+      font-family: Arial;
+      pointer-events: none;
+    }
   </style>
 </head>
 
@@ -59,6 +69,7 @@
 
 <div id="game">
   <div id="score">Score: 0</div>
+  <div id="instructions">Press Space or Up Arrow to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
💡 **What:** Added visible on-screen instructions ("Press Space or Up Arrow to jump") to the Mario game in `src/views/mario-game.njk`.
🎯 **Why:** Web games with custom keyboard controls suffer from poor discoverability; users don't automatically know how to interact.
📸 **Before/After:** See the UI screenshot verification.
♿ **Accessibility/UX:** Improved cognitive accessibility by explicitly stating required controls, reducing trial-and-error friction for users. Used `pointer-events: none` to ensure the new text overlay does not interfere with mouse/touch interactions on the canvas.

---
*PR created automatically by Jules for task [7414917989781973329](https://jules.google.com/task/7414917989781973329) started by @EiJackGH*