### PR TITLE
🎨 Palette: Add explicit keyboard instructions to Mario game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+
+## 2026-07-24 - Explicit Keyboard Instructions
+**Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, always provide explicit, visible instructional text so users know the required inputs.
+**Action:** Add static text instructions to game UI (ensuring they have `pointer-events: none` if they float over the game canvas so they don't block clicks) when mapping custom controls.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,6 +52,17 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 40px;
+      left: 10px;
+      color: rgba(255, 255, 255, 0.9);
+      font-size: 16px;
+      font-family: Arial;
+      pointer-events: none;
+      text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
+    }
   </style>
 </head>
 
@@ -59,6 +70,7 @@
 
 <div id="game">
   <div id="score">Score: 0</div>
+  <div id="instructions">Press Space or ↑ to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
💡 What: Added explicit keyboard instructions ("Press Space or ↑ to jump") below the score in the Mario game canvas.
🎯 Why: Without visual cues, users have to guess the custom keyboard controls to play the game, leading to a poor initial user experience.
📸 Before/After: See screenshot provided during UI verification.
♿ Accessibility: Ensures the instruction text is available to screen readers while keeping it visually distinct via CSS. Added `pointer-events: none` to avoid blocking interactions.

---
*PR created automatically by Jules for task [4041746752226331474](https://jules.google.com/task/4041746752226331474) started by @EiJackGH*