### PR TITLE
🎨 Palette: Add keyboard instructions to Mario Game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+
+## 2025-07-27 - Explicit Custom Keyboard Instructions
+**Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users may not know the required inputs without visible cues.
+**Action:** Always provide explicit, visible instructional text (like "Press Space to jump") so users know the required inputs, using `pointer-events: none` to avoid blocking interactivity.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,6 +52,16 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 40px;
+      left: 10px;
+      color: rgba(255, 255, 255, 0.8);
+      font-size: 14px;
+      font-family: Arial;
+      pointer-events: none;
+    }
   </style>
 </head>
 
@@ -59,6 +69,7 @@
 
 <div id="game">
   <div id="score">Score: 0</div>
+  <div id="instructions">Press Space or &uarr; to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
💡 **What:** Added visible instructional text ("Press Space or ↑ to jump") to the Mario game canvas.
🎯 **Why:** Users need explicit cues to know which custom keyboard inputs are required for interactivity, preventing confusion.
📸 **Before/After:** The game now displays a subtle, non-blocking text overlay below the score.
♿ **Accessibility:** Added explicit visual cues for keyboard controls without interfering with page flow.

---
*PR created automatically by Jules for task [12148440287625353964](https://jules.google.com/task/12148440287625353964) started by @EiJackGH*