### PR TITLE
🎨 Palette: Add explicit keyboard instructions to Mario game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+
+## 2024-07-30 - Keyboard Instructions
+**Learning:** Interactive HTML5 widgets with custom keybindings require explicit, visible instructional text so users know the required inputs.
+**Action:** Add explicit instructional text for custom keyboard bindings.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,6 +52,15 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      color: white;
+      font-family: Arial;
+      pointer-events: none;
+    }
   </style>
 </head>
 
@@ -59,6 +68,7 @@
 
 <div id="game">
   <div id="score">Score: 0</div>
+  <div id="instructions">Press Space or Up Arrow to jump</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
Added a micro-UX improvement to the Mario game by displaying explicit keyboard instructions ("Press Space or Up Arrow to jump") in the top right corner. This reduces cognitive load and makes the interface more intuitive for users relying on keyboard controls, fulfilling the Palette persona's mission. The styling ensures the instructions don't block interaction with the game itself. A relevant entry was also added to the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [16770957042536814030](https://jules.google.com/task/16770957042536814030) started by @EiJackGH*