### PR TITLE
🎨 Palette: Add keyboard instructions to Mario Game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-23 - Game Key Scrolling
 **Learning:** Browsers natively scroll the page when users press Space or Arrow keys. When building a web-based game, this creates a frustrating UX where the game viewport jumps around while playing.
 **Action:** Always call `e.preventDefault()` on keydown events for typical game controls ("Space", "ArrowUp", etc.) when the focus is on a game container or the body.
+## 2025-07-31 - Explicit Game Controls
+**Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users may not intuitively know which keys to press, leading to confusion.
+**Action:** Always provide explicit, visible instructional text for custom keyboard controls so users know the required inputs.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -52,6 +52,16 @@
       font-size: 20px;
       font-family: Arial;
     }
+
+    #instructions {
+      position: absolute;
+      top: 40px;
+      left: 10px;
+      color: white;
+      font-size: 16px;
+      font-family: Arial;
+      pointer-events: none;
+    }
   </style>
 </head>
 
@@ -59,6 +69,7 @@
 
 <div id="game">
   <div id="score">Score: 0</div>
+  <div id="instructions">Press Space or ↑ to jump!</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
💡 What: Added explicit on-screen keyboard instructions ("Press Space or ↑ to jump!") to the Mario Game UI.
🎯 Why: Without visual cues, users may not know the required keybindings to play the game, leading to frustration.
📸 Before/After: The game previously only displayed the score. It now displays instructions directly below the score.
♿ Accessibility: Instructions are visible and accessible to screen readers. The element uses `pointer-events: none` to ensure it does not block any interaction with the game canvas.

---
*PR created automatically by Jules for task [15395852756696330994](https://jules.google.com/task/15395852756696330994) started by @EiJackGH*