### PR TITLE
🎨 Palette: Make score dynamic updates screen-reader friendly

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,7 @@
 ## 2025-07-31 - Explicit Game Controls
 **Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users may not intuitively know which keys to press, leading to confusion.
 **Action:** Always provide explicit, visible instructional text for custom keyboard controls so users know the required inputs.
+
+## 2025-08-01 - Aria-Live Static Text Separation
+**Learning:** Do not place static text (like instructions or labels) inside an `aria-live` region, as it forces screen readers to unnecessarily repeat the static text every time the dynamic content updates.
+**Action:** Extract static text into a separate sibling element or parent, leaving only the dynamic value inside the `aria-live` region.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -68,7 +68,7 @@
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score">Score: <span id="score-val" aria-live="polite">0</span></div>
   <div id="instructions">Press Space or ↑ to jump!</div>
   <div id="mario"></div>
   <div class="ground"></div>
@@ -77,7 +77,7 @@
 <script>
   const mario = document.getElementById("mario");
   const game = document.getElementById("game");
-  const scoreText = document.getElementById("score");
+  const scoreVal = document.getElementById("score-val");
 
   let jumping = false;
   let score = 0;
@@ -129,7 +129,7 @@
         clearInterval(move);
         goomba.remove();
         score++;
-        scoreText.innerText = "Score: " + score;
+        scoreVal.innerText = score;
       } else {
         position -= 6;
         goomba.style.left = position + "px";


### PR DESCRIPTION
💡 **What:** Extracted the static "Score:" label from the dynamic score value in the `mario-game.njk` DOM. 
🎯 **Why:** Previously, if `aria-live` was added to the entire `#score` div, screen readers would read "Score: 1", "Score: 2", "Score: 3", which is highly repetitive and annoying. By separating the dynamic number into its own `aria-live` span, the screen reader elegantly reads just the updated number.
📸 **Before/After:** Visually identical, but audibly much improved.
♿ **Accessibility:** Added an `aria-live="polite"` region specifically constrained to the dynamic numerical score value.

---
*PR created automatically by Jules for task [9106948828511065574](https://jules.google.com/task/9106948828511065574) started by @EiJackGH*