### PR TITLE
🎨 Palette: Add aria-live to dynamic score in Mario game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,7 @@
 ## 2025-07-31 - Explicit Game Controls
 **Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users may not intuitively know which keys to press, leading to confusion.
 **Action:** Always provide explicit, visible instructional text for custom keyboard controls so users know the required inputs.
+
+## 2023-11-20 - Dynamic Score Accessibility
+**Learning:** Dynamic text changes, like game scores, are invisible to screen readers unless marked appropriately.
+**Action:** Add aria-live="polite" to dynamic score elements so updates are announced by screen readers without being intrusive.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -68,7 +68,7 @@
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score" aria-live="polite">Score: 0</div>
   <div id="instructions">Press Space or ↑ to jump!</div>
   <div id="mario"></div>
   <div class="ground"></div>


### PR DESCRIPTION
💡 What: Added aria-live="polite" to the score display in the Mario game.
🎯 Why: Dynamic text updates (like a score changing) are not announced by screen readers by default. This makes the game's score inaccessible to those users.
📸 Before/After: Visuals remain unchanged. Screen readers will now announce score updates.
♿ Accessibility: Improved screen reader compatibility by explicitly marking the score container as a polite live region.

---
*PR created automatically by Jules for task [10281424370037989150](https://jules.google.com/task/10281424370037989150) started by @EiJackGH*