### PR TITLE
🎨 Palette: Make game score screen reader accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,7 @@
 ## 2025-07-31 - Explicit Game Controls
 **Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users may not intuitively know which keys to press, leading to confusion.
 **Action:** Always provide explicit, visible instructional text for custom keyboard controls so users know the required inputs.
+
+## 2025-05-15 - Screen Reader Dynamic Text
+**Learning:** Dynamic text changes, like game scores, are invisible to screen readers unless explicitly marked. Do not place static text inside an aria-live region, as it forces screen readers to unnecessarily repeat the static text every time the dynamic content updates.
+**Action:** Extract static text into a separate sibling element and add aria-live="polite" to the container of the dynamic value.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -44,7 +44,7 @@
       background: #2ecc71;
     }
 
-    #score {
+    #score-container {
       position: absolute;
       top: 10px;
       left: 10px;
@@ -68,7 +68,7 @@
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score-container">Score: <span id="score" aria-live="polite">0</span></div>
   <div id="instructions">Press Space or ↑ to jump!</div>
   <div id="mario"></div>
   <div class="ground"></div>
@@ -129,7 +129,7 @@
         clearInterval(move);
         goomba.remove();
         score++;
-        scoreText.innerText = "Score: " + score;
+        scoreText.innerText = score;
       } else {
         position -= 6;
         goomba.style.left = position + "px";


### PR DESCRIPTION
💡 **What:** Added `aria-live="polite"` to the game score counter and separated the static "Score: " text from the dynamically updating number.

🎯 **Why:** Previously, the game's score text was updated as a single string (e.g. "Score: 1"). Because screen readers couldn't see these dynamic DOM updates without an ARIA region, the updates were totally silent to visually impaired users. Further, if we just put the whole text in an `aria-live` region, the screen reader would painfully announce "Score: 1... Score: 2..." instead of just the new value.

♿ **Accessibility:** By isolating the number in a `<span>` with `aria-live="polite"`, screen readers will gracefully read out the new number ("1", "2") as the score increments, without repeating the static label.

🎨 **Palette** - painting small strokes of UX excellence!

---
*PR created automatically by Jules for task [5118603954858363715](https://jules.google.com/task/5118603954858363715) started by @EiJackGH*