### PR TITLE
🎨 Palette: Improve screen reader UX for dynamic game score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,6 @@
 ## 2025-07-31 - Explicit Game Controls
 **Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users may not intuitively know which keys to press, leading to confusion.
 **Action:** Always provide explicit, visible instructional text for custom keyboard controls so users know the required inputs.
+## 2024-05-24 - Dynamic Score Announcement
+**Learning:** Dynamic text changes like game scores are invisible to screen readers unless explicitly marked. Also, static text should not be inside an aria-live region to avoid repetition.
+**Action:** Extract static text and add aria-live="polite" to the container of the dynamic value.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -44,7 +44,7 @@
       background: #2ecc71;
     }
 
-    #score {
+    #score-container {
       position: absolute;
       top: 10px;
       left: 10px;
@@ -68,7 +68,10 @@
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score-container">
+    <span>Score: </span>
+    <span id="score-value" aria-live="polite">0</span>
+  </div>
   <div id="instructions">Press Space or ↑ to jump!</div>
   <div id="mario"></div>
   <div class="ground"></div>
@@ -77,7 +80,7 @@
 <script>
   const mario = document.getElementById("mario");
   const game = document.getElementById("game");
-  const scoreText = document.getElementById("score");
+  const scoreText = document.getElementById("score-value");
 
   let jumping = false;
   let score = 0;
@@ -129,7 +132,7 @@
         clearInterval(move);
         goomba.remove();
         score++;
-        scoreText.innerText = "Score: " + score;
+        scoreText.innerText = score;
       } else {
         position -= 6;
         goomba.style.left = position + "px";


### PR DESCRIPTION
💡 What: Extracted the static "Score: " text from the dynamic score value in the Mario game view and added `aria-live="polite"` to the dynamic score container.

🎯 Why: Dynamic text changes, like game scores increasing, are invisible to screen readers unless explicitly marked as a live region. Furthermore, keeping static text out of the live region ensures the screen reader only announces the new number rather than repeatedly saying "Score: [number]".

📸 Before/After: Visual presentation is identical. Screen reader experience is improved.

♿ Accessibility: Added `aria-live="polite"` to dynamically changing text value to ensure updates are announced to screen reader users without being intrusive.

---
*PR created automatically by Jules for task [13331026816469925169](https://jules.google.com/task/13331026816469925169) started by @EiJackGH*