### PR TITLE
🎨 Palette: Make game score screen reader accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,7 @@
 ## 2025-07-31 - Explicit Game Controls
 **Learning:** When building interactive HTML5 widgets or games with custom keyboard event bindings, users may not intuitively know which keys to press, leading to confusion.
 **Action:** Always provide explicit, visible instructional text for custom keyboard controls so users know the required inputs.
+
+## 2024-08-06 - Screen Reader Accessible Dynamic Text
+**Learning:** Dynamic text changes, like game scores, are invisible to screen readers unless explicitly marked. Do not place static text (like instructions) inside an `aria-live` region, as it forces screen readers to unnecessarily repeat the static text every time the dynamic content updates. Extract static text into a separate sibling element.
+**Action:** Add `aria-live="polite"` to the container of the dynamic value and extract static text out of it.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -44,7 +44,7 @@
       background: #2ecc71;
     }
 
-    #score {
+    #score-container {
       position: absolute;
       top: 10px;
       left: 10px;
@@ -68,7 +68,7 @@
 <body>
 
 <div id="game">
-  <div id="score">Score: 0</div>
+  <div id="score-container">Score: <span id="score-value" aria-live="polite">0</span></div>
   <div id="instructions">Press Space or ↑ to jump!</div>
   <div id="mario"></div>
   <div class="ground"></div>
@@ -77,7 +77,7 @@
 <script>
   const mario = document.getElementById("mario");
   const game = document.getElementById("game");
-  const scoreText = document.getElementById("score");
+  const scoreText = document.getElementById("score-value");
 
   let jumping = false;
   let score = 0;
@@ -129,7 +129,7 @@
         clearInterval(move);
         goomba.remove();
         score++;
-        scoreText.innerText = "Score: " + score;
+        scoreText.innerText = score;
       } else {
         position -= 6;
         goomba.style.left = position + "px";


### PR DESCRIPTION
## 💡 What
Separated the dynamic game score from the static "Score:" label and added `aria-live="polite"` to the dynamic element.

## 🎯 Why
Previously, the static text and dynamic text were merged. When the score updated, a screen reader could miss it or would have to repeat "Score: " every time the number incremented. By separating them and marking the dynamic part with `aria-live`, we ensure users with assistive technologies get concise, timely updates.

## 📸 Before/After
Visually, the UI looks identical, as validated by Playwright tests. However, the DOM structure has been refactored for accessibility.

## ♿ Accessibility
Added `aria-live="polite"` to `#score-value` so that screen readers announce the numeric updates accurately without being intrusive.

---
*PR created automatically by Jules for task [3872547246104903494](https://jules.google.com/task/3872547246104903494) started by @EiJackGH*