### PR TITLE
🎨 Palette: Add semantic <kbd> tags for keyboard shortcut discoverability

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2024-08-06 - Screen Reader Accessible Dynamic Text
 **Learning:** Dynamic text changes, like game scores, are invisible to screen readers unless explicitly marked. Do not place static text (like instructions) inside an `aria-live` region, as it forces screen readers to unnecessarily repeat the static text every time the dynamic content updates. Extract static text into a separate sibling element.
 **Action:** Add `aria-live="polite"` to the container of the dynamic value and extract static text out of it.
+
+## 2025-10-27 - Keyboard Shortcuts Semantics
+**Learning:** Explicitly highlighting keyboard shortcuts using semantic <kbd> tags with physical key styling improves intuitiveness and discoverability for users playing web games or using custom keyboard inputs.
+**Action:** Always wrap key shortcuts in <kbd> and apply text-shadows to ensure high contrast against dynamic backgrounds.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -61,6 +61,20 @@
       font-size: 16px;
       font-family: Arial;
       pointer-events: none;
+      text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+    }
+
+    kbd {
+      background-color: #f7f7f7;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
+      color: #333;
+      display: inline-block;
+      font-family: monospace;
+      font-size: 14px;
+      padding: 2px 6px;
+      text-shadow: none; /* override the parent shadow for clear text on the key */
     }
   </style>
 </head>
@@ -69,7 +83,7 @@
 
 <div id="game">
   <div id="score-container">Score: <span id="score-value" aria-live="polite">0</span></div>
-  <div id="instructions">Press Space or ↑ to jump!</div>
+  <div id="instructions">Press <kbd>Space</kbd> or <kbd>↑</kbd> to jump!</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
💡 What: Wrapped the keyboard shortcut instructions ("Space" and "↑") in the Mario Game with semantic `<kbd>` tags and applied physical key styling (border, background, box-shadow) via CSS. Also added a text shadow to the instruction container to ensure the text remains legible over the game's background.

🎯 Why: To make the interface more intuitive and the controls more discoverable. Highlighting keyboard shortcuts visually reduces cognitive load for users and provides clear, immediate affordance for interactive game controls.

📸 Before/After: Before, the text "Space or ↑" blended in with the rest of the instructional sentence. After, "Space" and "↑" look like physical keys on a keyboard, clearly indicating they are user inputs. (Validated via Playwright screenshot).

♿ Accessibility: Using semantic `<kbd>` tags is the appropriate HTML standard for representing user input. It provides better structure for assistive technologies and improves the overall semantic meaning of the document.

---
*PR created automatically by Jules for task [3226167368258930428](https://jules.google.com/task/3226167368258930428) started by @EiJackGH*