### PR TITLE
🎨 Palette: Add keyboard shortcut styling to game instructions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2024-08-06 - Screen Reader Accessible Dynamic Text
 **Learning:** Dynamic text changes, like game scores, are invisible to screen readers unless explicitly marked. Do not place static text (like instructions) inside an `aria-live` region, as it forces screen readers to unnecessarily repeat the static text every time the dynamic content updates. Extract static text into a separate sibling element.
 **Action:** Add `aria-live="polite"` to the container of the dynamic value and extract static text out of it.
+
+## 2025-10-18 - Keyboard Shortcut Highlight
+**Learning:** Explicitly highlighting keyboard shortcuts using semantic `<kbd>` tags with physical key styling improves intuitiveness and discoverability.
+**Action:** Always wrap key shortcuts in `<kbd>` and apply text-shadows to ensure high contrast against dynamic backgrounds.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -62,6 +62,21 @@
       font-family: Arial;
       pointer-events: none;
     }
+
+    kbd {
+      background-color: #f7f7f7;
+      border: 1px solid #ccc;
+      border-radius: 3px;
+      box-shadow: 0 1px 0 rgba(0,0,0,0.2), 0 0 0 2px #fff inset;
+      color: #333;
+      display: inline-block;
+      font-family: monospace;
+      font-size: 14px;
+      line-height: 1.4;
+      margin: 0 .1em;
+      padding: .1em .6em;
+      text-shadow: 0 1px 0 #fff;
+    }
   </style>
 </head>
 
@@ -69,7 +84,7 @@
 
 <div id="game">
   <div id="score-container">Score: <span id="score-value" aria-live="polite">0</span></div>
-  <div id="instructions">Press Space or ↑ to jump!</div>
+  <div id="instructions">Press <kbd>Space</kbd> or <kbd>&uarr;</kbd> to jump!</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
### 💡 What
Wrapped the keyboard instructions ("Space" and "↑") in semantic `<kbd>` tags and applied CSS styling to render them as physical keys.

### 🎯 Why
When presenting users with custom keyboard controls, raw text can easily blend into the background or be overlooked. By explicitly styling them as physical keys (with borders and text shadows), it reduces cognitive load and makes the required inputs immediately discoverable and intuitive to use.

### 📸 Before/After
**Before:** Text simply read `Press Space or ↑ to jump!` blending in with standard paragraph styling.
**After:** The keys `Space` and `↑` are distinctly styled as keyboard buttons with a light background and drop shadows to stand out against the dynamic game background.

### ♿ Accessibility
Improves accessibility by explicitly communicating interactivity through distinct, recognizable physical affordances. The use of the semantic `<kbd>` element correctly denotes keyboard input for assistive technologies.

---
*PR created automatically by Jules for task [6296474647881729026](https://jules.google.com/task/6296474647881729026) started by @EiJackGH*