### PR TITLE
🎨 Palette: Add semantic styling to keyboard shortcuts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2024-08-06 - Screen Reader Accessible Dynamic Text
 **Learning:** Dynamic text changes, like game scores, are invisible to screen readers unless explicitly marked. Do not place static text (like instructions) inside an `aria-live` region, as it forces screen readers to unnecessarily repeat the static text every time the dynamic content updates. Extract static text into a separate sibling element.
 **Action:** Add `aria-live="polite"` to the container of the dynamic value and extract static text out of it.
+
+## 2026-08-11 - Semantic Keyboard Instructions
+**Learning:** Explicitly highlighting keyboard shortcuts using semantic `<kbd>` tags with physical key styling improves intuitiveness and discoverability. Always wrap key shortcuts in `<kbd>` and apply text-shadows to ensure high contrast against dynamic backgrounds.
+**Action:** Use `<kbd>` tags with a standardized CSS class for all inline keyboard shortcut instructions to visually distinguish them as actionable physical keys.

--- a/src/views/mario-game.njk
+++ b/src/views/mario-game.njk
@@ -62,6 +62,21 @@
       font-family: Arial;
       pointer-events: none;
     }
+
+    kbd {
+      background-color: #eee;
+      border-radius: 3px;
+      border: 1px solid #b4b4b4;
+      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2), 0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
+      color: #333;
+      display: inline-block;
+      font-size: 0.85em;
+      font-weight: 700;
+      line-height: 1;
+      padding: 2px 4px;
+      white-space: nowrap;
+      text-shadow: 0 1px 0 #fff;
+    }
   </style>
 </head>
 
@@ -69,7 +84,7 @@
 
 <div id="game">
   <div id="score-container">Score: <span id="score-value" aria-live="polite">0</span></div>
-  <div id="instructions">Press Space or ↑ to jump!</div>
+  <div id="instructions">Press <kbd>Space</kbd> or <kbd>↑</kbd> to jump!</div>
   <div id="mario"></div>
   <div class="ground"></div>
 </div>


### PR DESCRIPTION
* 💡 What: Wrapped keyboard instructions ("Space", "↑") in `<kbd>` tags and added a custom CSS class to make them look like physical keys.
* 🎯 Why: Improves intuitiveness and discoverability for users interacting with the game container.
* 📸 Before/After: See Playwright screenshot in PR attachments.
* ♿ Accessibility: Semantic tags provide clearer instructions for screen readers, and text-shadow ensures high contrast against dynamic backgrounds.

---
*PR created automatically by Jules for task [3545265902463336287](https://jules.google.com/task/3545265902463336287) started by @EiJackGH*